### PR TITLE
Fix lnks on quarks.documentation header.

### DIFF
--- a/_includes/docHeader.html
+++ b/_includes/docHeader.html
@@ -10,7 +10,7 @@
 		</div>
 		<div class="collapse navbar-collapse" id="navbar-main">
 			<ul class="nav navbar-nav">
-				<li><a href="http://quarks-edge.github.io" target="_blank">Github</a>
+				<li><a href="https://github.com/quarks-edge/quarks.documentation" target="_blank">Github</a>
 				</li>
 				<li><a
 					href="http://quarks-edge.github.io/quarks.documentation"
@@ -18,7 +18,7 @@
 			</ul>
 			<ul class="nav navbar-nav navbar-right">
 				<li><a
-					href="https://github.com/quarks-edge/quarks/issues/new?title=Feedback for {{page.url}}"
+					href="https://github.com/quarks-edge/quarks.documentation/issues/new?title=Feedback for {{page.url}}"
 					target="_blank">Feedback</a></li>
 				<li><a
 					href="https://github.com/quarks-edge/quarks"


### PR DESCRIPTION
On the documentation header correct links:

GitHub to the github project site for quarks.documentation (not the quarks-edge web site)

Feedback to the issues for quarks.documentation since this is doc issues, not Quarks code issues.
