### PR TITLE
Changed first section

### DIFF
--- a/docs/quarks/committers.md
+++ b/docs/quarks/committers.md
@@ -1,13 +1,13 @@
 ---
 layout: docs
 title: Committers  
-description: List of Quarks Committers and How to Become a Committer
+description: Commit Activity and How to Become a Committer
 weight: 30
 ---
 
-# Current Committers
+# Commit Activity
 
-To see a list of current committers click [here](https://github.com/orgs/quarks-edge/teams/quarkscommitters).
+To see commit activity for Quarks, click [here](https://github.com/quarks-edge/quarks/pulse).
 
 # How to Become a Committer
 


### PR DESCRIPTION
Not everyone had access to the original link that showed committers.  Changed the first section of this document to "Commit Activity" and linked to the pulse page.  This is to resolve quarks-edge.github.io #7.
