### PR TITLE
Updated the Javadoc link

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -11,7 +11,7 @@ Quarks is an open source programming model and runtime for edge devices that ena
 The quarks.documentation project includes resources that help you learn how to create your own Quarks applications.
 
 # Table of Contents
-* [Javadoc](https://quarks-edge.github.io/quarks/docs/javadoc/index.html)
+* [Quarks Javadoc](https://quarks-edge.github.io/quarks/docs/javadoc/index.html)
 {% include nav.html context="/docs/"%}
 
 # New Documentation


### PR DESCRIPTION
Made a minor update to the Javadoc link; I think it looks a little better.  Would be good to figure out a better way to get this link under Quarks in the doc table of contents.
